### PR TITLE
Poweroff guard + reliable outage shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## WIP
+Reliable unattended recovery after power failures: the Pi now always comes back on its own when AC power returns, and outage shutdown behavior matches the configuration.
+
+- Add `ups-poweroff-guard.service`: converts a poweroff into a reboot when AC power is still present, closing the race where power returns during the shutdown grace period and the Pi would stay off until a button press
+- Fix `ac_max_downtime` being ignored while the battery is above its charge target (power cut at full battery previously drained to the minimums regardless of the setting)
+- Rewrite `install.sh`: idempotent re-runs, installs the guard, stages required EEPROM settings (`POWER_OFF_ON_HALT=1`, `PSU_MAX_CURRENT=5000`), never overwrites an existing config
+- Change default config to battery-based shutdown: `ac_max_downtime: 0`, `min_charge_capacity: 25`
+- Document the AC-restore-edge behavior, the guard, and a full-cycle test procedure in the README
+
+## 1.0.0
+Initial fork state: upstream daemon plus combined HTTP REST API / WebSocket status server (`api_port`, default 6969).

--- a/README.md
+++ b/README.md
@@ -17,12 +17,51 @@ I wrote this because I needed something a bit more robust and flexible than what
 - It is meant to run as a systemd service, but can be run directly.
 - A temperature sensor attached to the lithium-cells can be used to monitor the cells to be in the correct temperature range for charging or dis-charging. Currently the Adafruit DHT22 and DHT11 are implemented. Pull requests for other types are welcome.
 - Cool down the case by spinning the system fan when the batteries reach 50C.
+- Guarantees the Pi comes back on its own after a power failure — including the corner case where power returns during the shutdown itself (see below).
+
+## Automatic restart after a power failure
+
+The X120x auto-power-on only triggers on an **AC power-restore edge**: the
+board re-enables its output when adapter power (re)appears while the output is
+off. Two things must be true for unattended recovery, and this repo handles
+both:
+
+1. **The Pi must really power off** so the UPS stops detecting it and cuts its
+   own output (preserving the battery and arming auto-power-on). That requires
+   the `POWER_OFF_ON_HALT=1` EEPROM setting — `install.sh` checks and stages it
+   (together with `PSU_MAX_CURRENT=5000`) automatically.
+2. **The Pi must never power off while AC is present.** If power returns
+   during the shutdown grace period and the cancellation loses the race, the
+   system completes its poweroff with AC already present — no restore edge
+   will ever come, and the Pi waits for a button press forever. The
+   `ups-poweroff-guard.service` installed by this repo runs at the very end of
+   every poweroff and converts it into a reboot when AC (GPIO6, the X120x
+   power-loss-detection pin) is present.
+
+To intentionally shut down and stay off while AC is present:
+```
+sudo touch /run/ups-poweroff-guard.skip && sudo poweroff
+```
+
+Also note: on a power failure the daemon now always starts the
+`ac_max_downtime` timer. Previously the timer only started when the battery
+was below its charge target, so a power cut with a full battery would run the
+battery all the way down to the minimums regardless of `ac_max_downtime`.
+
+### Testing the full cycle
+
+1. Pull the AC adapter.
+2. Wait for the configured shutdown (with `ac_max_downtime: 0` the default
+   config shuts down at 25% capacity; for a quick test set `ac_max_downtime: 1`
+   → poweroff after ~2 minutes). The UPS LEDs go dark a few seconds after the
+   Pi powers off.
+3. Reconnect the adapter: the Pi boots by itself. No button press needed.
 
 ## Install
 1. Clone or download this repository.
 2. Review the `x12x_ups.ini` and set according to your needs. [^1]
 3. Review and understand the provided `install.sh` script as it is a good practice. 
-4. Run it with `sudo sh -x ./install.sh` to install files and dependencies and enable and start the service.
+4. Run it with `sudo ./install.sh` to install files and dependencies and enable and start the daemon and the poweroff guard. The script also stages the required EEPROM settings (`POWER_OFF_ON_HALT=1`, `PSU_MAX_CURRENT=5000`) — reboot once if it reports staged changes. Re-running the script is safe; an existing `/usr/local/etc/x120x_upsd.ini` is kept as-is.
 5. Optionally: To stop charging quickly after power on so that the deamon can manage it, add `gpio=16=pu` to `/boot/firware/config.txt` and reboot.
 6. Optionally: If using the DHT11 or DHT22 temperature sensor to monitor the lithium cell(s) add the adafruit dht package to your system and the system packages it depends on[^2]:
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,16 @@
 #!/bin/sh
+# Installer for the x120x UPS daemon + poweroff guard.
+# Idempotent: safe to re-run for updates. An existing /usr/local/etc/x120x_upsd.ini
+# is never overwritten (compare it with x120x_upsd.ini in this repo after updates).
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run as root: sudo ./install.sh" >&2
+    exit 1
+fi
+cd "$(dirname "$0")"
+
+echo "== Installing dependencies"
 apt install -y python3-apscheduler python3-decorator python3-gpiozero \
     python3-smbus2 python3-systemd
 
@@ -11,14 +23,55 @@ if [ -z "$API_PORT" ]; then API_PORT="6969"; fi
 if [ "$API_PORT" != "0" ]; then
     apt install -y python3-websockets
 fi
-cp x120x_upsd.py /usr/local/bin
-cp -n x120x_upsd.ini /usr/local/etc || true
-cp x120x_upsd.service /etc/systemd/system
 
-chown root:root /usr/local/bin/x120x_upsd.py /usr/local/etc/x120x_upsd.ini /etc/systemd/system/x120x_upsd.service
-chmod 644 /usr/local/etc/x120x_upsd.ini /etc/systemd/system/x120x_upsd.service
-chmod 755 /usr/local/bin/x120x_upsd.py
+echo "== Installing UPS daemon"
+install -m 755 -o root -g root x120x_upsd.py /usr/local/bin/x120x_upsd.py
+if [ -f /usr/local/etc/x120x_upsd.ini ]; then
+    echo "   Keeping existing /usr/local/etc/x120x_upsd.ini (repo default not applied)"
+else
+    install -m 644 -o root -g root x120x_upsd.ini /usr/local/etc/x120x_upsd.ini
+fi
+install -m 644 -o root -g root x120x_upsd.service /etc/systemd/system/x120x_upsd.service
 
+echo "== Installing poweroff guard"
+# Without the guard, a poweroff that completes while AC power is present
+# (e.g. power returns during the shutdown grace period) leaves the Pi off
+# forever: the X120x only powers it back on via an AC restore edge.
+install -m 755 -o root -g root ups-poweroff-guard.sh /usr/local/sbin/ups-poweroff-guard.sh
+install -m 644 -o root -g root ups-poweroff-guard.service /etc/systemd/system/ups-poweroff-guard.service
+
+echo "== Enabling services"
 systemctl daemon-reload
-systemctl enable x120x_upsd.service
-systemctl start x120x_upsd.service
+systemctl enable x120x_upsd.service ups-poweroff-guard.service
+systemctl restart x120x_upsd.service
+
+echo "== Checking Raspberry Pi EEPROM settings"
+# POWER_OFF_ON_HALT=1 : Pi powers fully off on shutdown, so the UPS stops
+#                       detecting it, cuts its output and arms auto-power-on.
+# PSU_MAX_CURRENT=5000: accept the UPS's full 5A without throttling.
+if command -v rpi-eeprom-config >/dev/null 2>&1; then
+    CURRENT=$(rpi-eeprom-config)
+    WANTED=$CURRENT
+    for kv in POWER_OFF_ON_HALT=1 PSU_MAX_CURRENT=5000; do
+        key=${kv%%=*}
+        if printf '%s\n' "$WANTED" | grep -q "^${key}="; then
+            WANTED=$(printf '%s\n' "$WANTED" | sed "s/^${key}=.*/${kv}/")
+        else
+            WANTED=$(printf '%s\n%s' "$WANTED" "$kv")
+        fi
+    done
+    if [ "$CURRENT" = "$WANTED" ]; then
+        echo "   EEPROM settings already correct"
+    else
+        TMP=$(mktemp)
+        printf '%s\n' "$WANTED" > "$TMP"
+        rpi-eeprom-config --apply "$TMP"
+        rm -f "$TMP"
+        echo "   EEPROM settings staged - REBOOT REQUIRED to apply them"
+    fi
+else
+    echo "   rpi-eeprom-config not found - set POWER_OFF_ON_HALT=1 and PSU_MAX_CURRENT=5000 manually"
+fi
+
+echo "== Done"
+systemctl --no-pager --lines 0 status x120x_upsd.service | head -3

--- a/ups-poweroff-guard.service
+++ b/ups-poweroff-guard.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Reboot instead of poweroff when UPS AC power is present
+DefaultDependencies=no
+After=final.target
+Before=systemd-poweroff.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/ups-poweroff-guard.sh
+
+[Install]
+WantedBy=poweroff.target

--- a/ups-poweroff-guard.sh
+++ b/ups-poweroff-guard.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# X120x UPS poweroff guard.
+#
+# The X120x boards only power the Pi back on via an AC power-restore edge.
+# If the system powers off while AC is already present (e.g. power returned
+# during the shutdown grace period and the cancel lost the race), no edge
+# will ever come and the Pi stays off until the button is pressed.
+#
+# This script runs at the very end of every poweroff (see
+# ups-poweroff-guard.service): if AC power is present at that moment, the
+# poweroff is converted into a reboot instead.
+#
+# GPIO6 is the X120x power-loss-detection pin: high = AC present.
+#
+# To intentionally power off while AC is present, skip the guard once with:
+#   sudo touch /run/ups-poweroff-guard.skip && sudo poweroff
+[ -e /run/ups-poweroff-guard.skip ] && exit 0
+case "$(pinctrl get 6 2>/dev/null)" in
+  *"| hi"*)
+    echo "ups-poweroff-guard: AC present at poweroff, rebooting instead" > /dev/kmsg
+    systemctl --force reboot
+    ;;
+esac
+exit 0

--- a/x120x_upsd.ini
+++ b/x120x_upsd.ini
@@ -9,15 +9,20 @@ min_voltage: 3.5
 # Max charge capacity percentage
 max_charge_capacity: 80
 
-# Min charge capacity percentage on which to shutdown
-min_charge_capacity: 20
+# Min charge capacity percentage on which to shutdown.
+# 25 leaves margin for fuel-gauge optimism under load and for the ~5 minute
+# shutdown grace period, while staying well above the 3.0V hardware cutoff.
+min_charge_capacity: 25
 
 # Schedule for reporting battery state. Uses cron format
 # https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron
 battery_report_schedule: 0 * * * *
 
-# Max time for (AC) power to be off. 0 = ignore value.
-ac_max_downtime: 5
+# Max time in minutes for (AC) power to be off before a shutdown is
+# initiated, regardless of battery level. 0 = ignore value: ride out the
+# outage on battery and only shut down at the min_voltage /
+# min_charge_capacity thresholds above.
+ac_max_downtime: 0
 
 # Time the system must already be running to warmup the batteries for charging or discharging 
 # (+10C env temp is advised)

--- a/x120x_upsd.py
+++ b/x120x_upsd.py
@@ -368,7 +368,6 @@ class UPS_monitor:
         self._max_duration = max_duration * 60
         self._timer_no_power = Timer()
         self._shutdown_initiated = False
-        self._msg_no_power_no_charging_sent = False
         self._monitor_battery_thread = None
         self._monitor_charger_thread = None
         self._stopsignal = stopsignal
@@ -429,18 +428,13 @@ class UPS_monitor:
 
     def _monitor_charger(self):
         while not self._stop_monitor_charger.is_set() or not (self._stopsignal != None and self._stopsignal.kill_now):
-            if not self._msg_no_power_no_charging_sent and not self._charger.present \
-                    and self._timer_no_power.elapsed_time() == 0 and not self.battery.needs_charging():
-                print('Power failed, but the battery does not need charging', flush=True)
-                self._msg_no_power_no_charging_sent = True
-            elif not self._charger.present and self._timer_no_power.elapsed_time() == 0 and self.battery.needs_charging():
+            if not self._charger.present and self._timer_no_power.elapsed_time() == 0:
                 self._timer_no_power.start()
                 print('Power failed.', flush=True)
             elif self._charger.present and self._timer_no_power.elapsed_time() != 0:
                 if self._shutdown_initiated:
                     self.cancel_shutdown()
                 print(f'Power returned after {self._timer_no_power.stop():0.0f} seconds', flush=True)
-                self._msg_no_power_no_charging_sent = False
             elif not self._shutdown_initiated and self._max_duration and self._timer_no_power.elapsed_time() >= self._max_duration:
                 self.initiate_5_minute_shutdown(f'Power failed for {(self._timer_no_power.elapsed_time()/60):0.0f} minutes')
             time.sleep(30)


### PR DESCRIPTION
## Summary

Guarantees unattended recovery after power failures on X120x UPS boards.

- **New `ups-poweroff-guard.service`** — the X120x only powers the Pi back on via an AC power-restore *edge*. If the system completes a poweroff while AC is already present (power returned during the shutdown grace period and the cancel lost the race — observed in production on 2026-07-11), no edge ever comes and the Pi stays off until a button press. The guard runs at the very end of every poweroff and converts it into a reboot when AC (GPIO6) is present. Escape hatch: `touch /run/ups-poweroff-guard.skip`.
- **Fix: `ac_max_downtime` was ignored above the charge target** — the outage timer only started when the battery "needed charging" (<`max_charge_capacity`). A power cut at full battery ran the pack all the way down to the minimums regardless of the setting. The timer now always starts on power failure.
- **install.sh rewritten** — root check, idempotent re-runs, installs daemon + guard, stages the required EEPROM settings (`POWER_OFF_ON_HALT=1`, `PSU_MAX_CURRENT=5000`), never overwrites an existing ini.
- **Default config** — battery-based shutdown: `ac_max_downtime: 0`, `min_charge_capacity: 25`.
- README section documenting the restore-edge behavior + full-cycle test procedure; CHANGELOG added.

## Testing
- Guard live-tested on a Pi 5 + X1202: `sudo poweroff` with AC present → journal shows "AC present at poweroff, rebooting instead" → back up in ~35 s.
- Full outage cycle live-tested: AC pulled → graceful shutdown → UPS cuts output → AC restored → Pi boots unattended.
- `python3 -m py_compile` and `sh -n` clean.

Proposed release after merge: **v1.1.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)